### PR TITLE
Remove autofocus from click handling

### DIFF
--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -14,7 +14,6 @@ button.addEventListener('click', e => {
 // avoid DRY: disabling menu
 const disableMenu = () => {
   button.setAttribute('aria-expanded', false);
-  button.focus();
 };
 
 //  close on escape


### PR DESCRIPTION
Hi @madrilene, I have started using your template and really enjoy the setup. Thank you for sharing it. 

I noticed an issue on mobile where any click outside the menu causes a  re-focus on the menu button.  This issue came up when I added a netlify form to my site, and the autofocus prevented users from entering information on mobile.

I don't see a need to have the autofocus, and the problem it causes seems to be worse than the benefit it provides. However, I could be missing context on this.

To demonstrate the issue, I took the screen recording below. In the recording, I am clicking in between the blog posts. The scroll to the top each time is automatic. 

![mobile-click-handling-issue](https://user-images.githubusercontent.com/31743831/230898745-aed59b8c-bc7e-4567-b8c4-46fd7d2f85da.gif)
