### PR TITLE
Anchor footer to page

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,6 +1,6 @@
 {% set activePage = page.url | url %}
 
-<footer class="site-foot" role="contentinfo">
+<footer class="site-foot sticky top-[100vh]" role="contentinfo">
   <div class="wrapper">
     <div class="site-foot__inner">
       <nav id="footernav" class="site-foot__inner text-step-0" aria-label="Footer">


### PR DESCRIPTION
The footer floats on pages that have less content, and seems a bit out of place with existing styling. Thanks!

Before:
<img width="450" alt="" src="https://github.com/madrilene/eleventy-excellent/assets/52119485/a0f2d3fa-e5b9-48a8-a27f-fecf6421117d">

After:
<img width="450" alt="" src="https://github.com/madrilene/eleventy-excellent/assets/52119485/69d66214-efaa-4624-8d4b-edfb6ca559bf">
