### PR TITLE
changed .codepen color variables

### DIFF
--- a/src/assets/css/blocks/code.css
+++ b/src/assets/css/blocks/code.css
@@ -212,8 +212,8 @@ pre[class*='language-'] {
 
 .codepen {
   padding: var(--space-xs);
-  color: var(--color-text-accent);
-  border: 2px dashed var(--color-bg-accent);
+  color: var(--color-primary);
+  border: 2px dashed var(--color-primary);
 }
 
 .cp_embed_wrapper {


### PR DESCRIPTION
The --color-text-accent and --color-bg-accent colors are not defined in the project.

Most likely this has been an oversight so I changed the variables to the primary color used.