### PR TITLE
Correct tag link

### DIFF
--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -22,7 +22,7 @@ schema: blog
 
       <!-- tags -->
       {% if tags.length > 1 %} {% for tag in tags %} {% if tag != "posts" %}
-      <a class="button post-tag" href="/tags/{{ tags[1] }}">
+      <a class="button post-tag" href="/tags/{{ tag }}">
         {{ tag }}
       </a>
       {% endif %} {% endfor %} {% endif %}


### PR DESCRIPTION
I was looking at using the Excellent Eleventy design and moving my posts in, and realized the `/tags/{{ tag }}` was initially wrong. 

Having this set to `{{ tags[1] }}` will always pull the first tag. I have quite a few and while the tags were listed out, the links to the right `/tags/` page was all set to the first item in the array. 