### PR TITLE
feat: add dotenv config support

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -7,6 +7,9 @@
  *  - `./config/transforms/index.js`
  */
 
+// register dotenv for process.env.* variables to pickup
+require('dotenv').config()
+
 // JSDoc comment: Hint VS Code for eleventyConfig autocompletion. © Henry Desroches - https://gist.github.com/xdesro/69583b25d281d055cd12b144381123bf
 
 /**


### PR DESCRIPTION
LOVE this theme - it's been my first introduction to 11ty. Thank you!

Really struggled with the sitemap generation (and other code I'm hoping to provide a PR for), until I realized that `process.env.URL`  is never going to work due to `dotenv` not being registered anywhere (that I could see).

