### PR TITLE
feat: add support for changefreq in sitemap

### DIFF
--- a/src/common/sitemap.njk
+++ b/src/common/sitemap.njk
@@ -15,6 +15,7 @@ excludeFromSitemap: true
     <url>
         <loc>{{ meta.url }}{{ page.url }}</loc>
         <lastmod>{{ lastmod | toIsoString }}</lastmod>
+        <changefreq>{{ page.data.changeFreq if page.data.changeFreq else "monthly" }}</changefreq>
     </url>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Noticed that the sitemap generation was missing a `changefreq` option. By default, it'll tag everything with `monthly` unless you provide an override in the page / post meta data.