### PR TITLE
feat: add support for eleventy-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@11ty/eleventy-plugin-inclusive-language": "^1.0.3",
         "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
+        "cross-env": "^7.0.3",
         "tailwindcss": "^3.0.23"
       },
       "devDependencies": {
@@ -2165,6 +2166,23 @@
       "dependencies": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "screenshots": "node ./config/scripts/generate-screenshots.mjs",
-    "dev:11ty": "eleventy --serve --watch",
-    "build:11ty": "eleventy",
+    "dev:11ty": "cross-env ELEVENTY_ENV=development eleventy --serve --watch",
+    "build:11ty": "cross-env ELEVENTY_ENV=production eleventy",
     "start": "run-p dev:*",
     "build": "run-s clean build:*"
   },
@@ -28,6 +28,7 @@
     "@11ty/eleventy-plugin-inclusive-language": "^1.0.3",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
+    "cross-env": "^7.0.3",
     "tailwindcss": "^3.0.23"
   },
   "devDependencies": {


### PR DESCRIPTION
Not sure if this is wanted for this project, but there's usually a case where it would be super helpful to determine which environment things are running in, in order to help with conditional logic.

aka. only include GA4 (or other analytics) snippet if the environment is `production`.

This should help expose that.