### PR TITLE
Updated card component to show all tags

### DIFF
--- a/src/_includes/components/card.njk
+++ b/src/_includes/components/card.njk
@@ -17,7 +17,16 @@
           if
           activateTags and item.data.tags.length > 1
         %}
-          <span class="button post-tag"> {{ item.data.tags[1] }} </span>
+          {# For cards with multiple tags, show all tags for the card #}
+          {% for tagButton in range( 0, item.data.tags.length ) %} 
+            {# Skip "administrative" tags like 'posts' and 'feature' #}
+            {% if 
+              (item.data.tags[ tagButton ] != "posts") and 
+              (item.data.tags[ tagButton ] != "feature") 
+            %}
+              <span class="button post-tag"> {{ item.data.tags[ tagButton ] }} </span>
+            {% endif %}
+          {% endfor %}
         {% endif %}
       </span>
     </div>


### PR DESCRIPTION
Thank you for creating this excellent starter! I have been using eleventy-excellent to build out my own site.

I found when I added multiple tags for my posts, only the first one was showing up for the user.

The fix below updates the card component to show all of the tags instead.

An "IF" statement provides for the exclusion of "administrative" tags, such as "posts" or "feature" while still publishing any tags meant to be displayed to the user.

Thanks!