### PR TITLE
Fixed robots.txt rules to be on separate lines

### DIFF
--- a/src/common/robots.njk
+++ b/src/common/robots.njk
@@ -3,5 +3,19 @@ permalink: /robots.txt
 eleventyExcludeFromCollections: true
 excludeFromSitemap: true
 ---
-User-agent: * Disallow: /404.html User-agent: GPTbot Disallow: / User-agent: ChatGPT-User Disallow: /
-User-agent: Google-Extended Disallow: / User-agent: Omgilibot Disallow: / Sitemap: {{ meta.url }}/sitemap.xml
+User-agent: * 
+Disallow: /404.html 
+
+User-agent: GPTbot 
+Disallow: / 
+
+User-agent: ChatGPT-User 
+Disallow: /
+
+User-agent: Google-Extended 
+Disallow: / 
+
+User-agent: Omgilibot 
+Disallow: / 
+
+Sitemap: {{ meta.url }}/sitemap.xml


### PR DESCRIPTION
I love what you have built with Eleventy Excellent v3! I'm using it to build a new website and wanted make a few suggestions as I come across potential improvements.

Each rule in robots.txt should be a separate line based on <https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt>](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt) so I have separated rules and groups accordingly.

Thanks for considering my contribution!