### PR TITLE
Fix transposition typo in blog tag and WebC tag

### DIFF
--- a/src/_layouts/blog.njk
+++ b/src/_layouts/blog.njk
@@ -26,7 +26,7 @@ layout: base
           if
           item.data.tags.length > 1
         %}
-          <div slot="tag" webc:nkoeep>
+          <div slot="tag" webc:nokeep>
             {% for tag in item.data.tags %}
               {% if tag != "posts" %}
                 <span class="button post-tag">{{ tag }}</span>

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -39,7 +39,7 @@ layout: base
                 if
                 item.data.tags.length > 1
               %}
-                <div slot="tag" webc:nkoeep>
+                <div slot="tag" webc:nokeep>
                   {% for tag in item.data.tags %}
                     {% if tag != "posts" %}
                       <span class="button post-tag">{{ tag }}</span>

--- a/src/posts/2022/2022-09-01-post-with-code.md
+++ b/src/posts/2022/2022-09-01-post-with-code.md
@@ -2,7 +2,7 @@
 title: 'Post with some code'
 description: 'Syntax Highlighting is achieved by a pack of Eleventy plugins. No browser/client JavaScript, highlight transformations are all done at build-time.'
 date: 2022-09-01
-tags: ['sytnax highlighting', 'feature']
+tags: ['syntax highlighting', 'feature']
 ---
 
 This theme uses 11ty's [Syntax Highlighting Plugin](https://www.11ty.dev/docs/plugins/syntaxhighlight/), a pack of Eleventy plugins for PrismJS syntax highlighting. No browser/client JavaScript, highlight transformations are all done at build-time.

--- a/src/posts/2022/2022-10-12-post-with-image.md
+++ b/src/posts/2022/2022-10-12-post-with-image.md
@@ -63,7 +63,7 @@ The class names are passed in the outer container, the `<picture>` or `<figure>`
 
 {% image "./src/assets/images/gallery/asturias-3.jpg", "A traditional Asturian village with it's raised granaries, surrounded by lush green hills and mountains", null, "lazy", "class-that-does-nothing", "(min-width:30em) 50vw, 100vw", [200, 400] %}
 
-## Markdown sytnax
+## Markdown syntax
 
 Thanks to the [markdown-it-eleventy-img](https://github.com/solution-loisir/markdown-it-eleventy-img) package markdown also has it own image syntax. `src` is already prepended here, see `config/plugins/markdown.js`.
 


### PR DESCRIPTION
Thanks for accepting my first PR!

I found two minor transposition typos so I thought I would mention them to you. One is in layouts with WebC tag (https://www.11ty.dev/docs/languages/webc/#webcnokeep) and the other is in sample posts with the tag/word 'syntax'.