### PR TITLE
Remove aria-labels on theme buttons

### DIFF
--- a/src/assets/scripts/bundle/theme-toggle.js
+++ b/src/assets/scripts/bundle/theme-toggle.js
@@ -60,8 +60,11 @@ function setPreference() {
 
 function reflectPreference() {
   document.firstElementChild.setAttribute('data-theme', theme.value);
-  document.querySelector('#light-theme-toggle')?.setAttribute('aria-label', lightLabel);
-  document.querySelector('#dark-theme-toggle')?.setAttribute('aria-label', darkLabel);
+  // Let the button content set its accessible name. There is no need for an aria-label on a button with visible text.
+  // This practice can become a problem when the page is translated by the browser as often aria-labels are left alone
+  // this code would override the translated language and confuse the user
+  // document.querySelector('#light-theme-toggle')?.setAttribute('aria-label', lightLabel);
+  // document.querySelector('#dark-theme-toggle')?.setAttribute('aria-label', darkLabel);
 }
 
 function updateMetaThemeColor() {

--- a/src/assets/scripts/bundle/theme-toggle.js
+++ b/src/assets/scripts/bundle/theme-toggle.js
@@ -60,9 +60,6 @@ function setPreference() {
 
 function reflectPreference() {
   document.firstElementChild.setAttribute('data-theme', theme.value);
-  // Let the button content set its accessible name. There is no need for an aria-label on a button with visible text.
-  // This practice can become a problem when the page is translated by the browser as often aria-labels are left alone
-  // this code would override the translated language and confuse the user
   // document.querySelector('#light-theme-toggle')?.setAttribute('aria-label', lightLabel);
   // document.querySelector('#dark-theme-toggle')?.setAttribute('aria-label', darkLabel);
 }


### PR DESCRIPTION
When a button has a visible label, let that label set the accessible name. Adding an aria-label that repeats the visible label in the original language doesn't help and can cause problems later. If a user translates the page in the browser, only the visible text will be translated, and the aria-labels will stay the same, overriding the content to set the accessible name.

For example, if a page is translated from English to Spanish, the theme button might show a label of "oscuro." But if the aria-label is set to English, its accessible name will stay "dark." This means a blind Spanish-speaking screen reader user would hear the English word when the page content is in Spanish, which would be confusing. Even worse, a voice-to-text user trying to click on that element might say "Haga clic en Oscuro," but it won't work because the accessible name doesn't match. This is the premise being [WCAG SC 2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name).