### PR TITLE
Fix image caption text contrast

### DIFF
--- a/src/assets/css/global/blocks/prose.css
+++ b/src/assets/css/global/blocks/prose.css
@@ -17,6 +17,11 @@
   border-bottom: 1px solid var(--color-bg-accent);
 }
 
+/* light text colour for captions shown against the dark gallery backdrop */
+.prose .gallery dialog.flow figcaption {
+  color: var(--color-base-light);
+}
+
 :where(.prose :is(h2, h3, h4)) {
   --flow-space: var(--space-xl);
 }


### PR DESCRIPTION
This commit changes the colour of caption text to Base Light to provide more contrast with the dark background.