### PR TITLE
Fix: taglist pagination

### DIFF
--- a/src/common/tagList.njk
+++ b/src/common/tagList.njk
@@ -1,7 +1,7 @@
 ---
 layout: tags
 pagination:
-  data: collections
+  data: collections.tagList
   size: 1
   alias: tag
 permalink: /tags/{{ tag }}/


### PR DESCRIPTION
I noticed that tag pages were being generated for every collection. This fix makes sure they're only generated for Tags.