### PR TITLE
Only load custom-easteregg.js if easter egg is on in meta.js

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -46,8 +46,9 @@
     <main id="main" class="flow">{{ content | safe }}</main>
 
     {% include "partials/footer.njk" %}
-
-    <script type="module" src="/assets/scripts/components/custom-easteregg.js"></script>
-    <custom-easteregg></custom-easteregg>
+    {%- if meta.easteregg -%}
+      <script type="module" src="/assets/scripts/components/custom-easteregg.js"></script>
+      <custom-easteregg></custom-easteregg>
+    {%- endif -%}
   </body>
 </html>


### PR DESCRIPTION
Avoid loading the extra custom-easteregg script if the easteregg is not turned on.