### PR TITLE
Add a link to the latest source code release.

### DIFF
--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -27,7 +27,7 @@ blog:
         connection speeds, and usage contexts.
       </p>
       <p>
-        <strong>This is version 4.</strong> I keep a
+        <strong>This is <a href="https://github.com/madrilene/eleventy-excellent/">version 4</a>.</strong> I keep a
         <a href="https://github.com/madrilene/eleventy-excellent/tree/v1">branch of v1</a>,
         <a href="https://github.com/madrilene/eleventy-excellent/tree/v2">v2</a> and <a href="https://github.com/madrilene/eleventy-excellent/tree/v3">v3</a>. I  tried to <a href="/get-started/#docs-lol">document most features and methodologies</a>.
       </p>


### PR DESCRIPTION
I found your starter from someone linking to https://eleventy-excellent.netlify.app (excellent work btw). 
But I was confused as the only links to the source code I could see were to older versions and the tiny github logo at the bottom of the page. 

This change adds a link to the source code near the top of the page to make it more obvious. 

Thanks