### PR TITLE
Fix clampGenerator when max and min are equal

### DIFF
--- a/src/_config/utils/clamp-generator.js
+++ b/src/_config/utils/clamp-generator.js
@@ -18,7 +18,7 @@ export const clampGenerator = tokens => {
 
   return tokens.map(({name, min, max}) => {
     if (min === max) {
-      return `${min / rootSize}rem`;
+      return {name, value:`${min / rootSize}rem`};
     }
 
     // Convert the min and max sizes to rems


### PR DESCRIPTION
The more complex code path returns an object of `name` & `value`. The code path when `min === max` currently only returns a value and tailwind config explodes 💣!

This change returns the correct object when max and min are equal.