### PR TITLE
Allow nested .webc components via updated glob pattern

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -47,7 +47,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPlugin(plugins.syntaxHighlight);
 
   eleventyConfig.addPlugin(plugins.webc, {
-    components: ['./src/_includes/webc/*.webc'],
+    components: ['./src/_includes/webc/**/*.webc'],
     useTransform: true
   });
 


### PR DESCRIPTION
Updated the Eleventy WebC plugin configuration to use a recursive glob pattern: from `./src/_includes/webc/*.webc` to `./src/_includes/webc/**/*.webc`.

This enables the use of nested folders for organizing WebC components, for example following Atomic Design principles (atoms, molecules, organisms…).