### PR TITLE
Refactor: externalize CSS and JS compilation to avoid dependency-based execution issues in Eleventy

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,8 +20,19 @@ import events from './src/_config/events.js';
 import filters from './src/_config/filters.js';
 import plugins from './src/_config/plugins.js';
 import shortcodes from './src/_config/shortcodes.js';
+import {buildAllCss} from './src/_config/plugins/css-config.js';
+import {buildAllJs} from './src/_config/plugins/js-config.js';
+
+
+
 
 export default async function (eleventyConfig) {
+
+  eleventyConfig.on('eleventy.before', async () => {
+    await buildAllCss();
+    await buildAllJs();
+  });
+
   eleventyConfig.addWatchTarget('./src/assets/**/*.{css,js,svg,png,jpeg}');
   eleventyConfig.addWatchTarget('./src/_includes/**/*.{webc}');
 
@@ -38,8 +49,6 @@ export default async function (eleventyConfig) {
 
   // ---------------------  Plugins
   eleventyConfig.addPlugin(plugins.htmlConfig);
-  eleventyConfig.addPlugin(plugins.cssConfig);
-  eleventyConfig.addPlugin(plugins.jsConfig);
   eleventyConfig.addPlugin(plugins.drafts);
 
   eleventyConfig.addPlugin(plugins.EleventyRenderPlugin);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
     "@11ty/eleventy-plugin-webc": "^0.11.2",
     "@11ty/is-land": "^4.0.1",
-    "fast-glob": "^3.3.3",
     "lite-youtube-embed": "^0.3.3",
     "tailwindcss": "^3.4.17"
   },
@@ -45,6 +44,7 @@
     "dayjs": "^1.11.13",
     "dotenv": "^17.2.0",
     "esbuild": "^0.25.8",
+    "fast-glob": "^3.3.3",
     "html-minifier-terser": "^7.2.0",
     "js-yaml": "^4.1.0",
     "markdown-it": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,14 @@
     "url": "https://github.com/madrilene/eleventy-excellent.git"
   },
   "dependencies": {
-    "@11ty/eleventy": "^3.1.1",
+    "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-fetch": "^5.1.0",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-plugin-rss": "^2.0.4",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
     "@11ty/eleventy-plugin-webc": "^0.11.2",
     "@11ty/is-land": "^4.0.1",
+    "fast-glob": "^3.3.3",
     "lite-youtube-embed": "^0.3.3",
     "tailwindcss": "^3.4.17"
   },

--- a/src/_config/plugins.js
+++ b/src/_config/plugins.js
@@ -12,10 +12,6 @@ import {drafts} from './plugins/drafts.js';
 // Custom transforms
 import {htmlConfig} from './plugins/html-config.js';
 
-// Custom template language
-import {cssConfig} from './plugins/css-config.js';
-import {jsConfig} from './plugins/js-config.js';
-
 export default {
   EleventyRenderPlugin,
   rss,
@@ -24,7 +20,5 @@ export default {
   eleventyImageTransformPlugin,
   markdownLib,
   drafts,
-  htmlConfig,
-  cssConfig,
-  jsConfig
+  htmlConfig
 };

--- a/src/_config/plugins/js-config.js
+++ b/src/_config/plugins/js-config.js
@@ -1,45 +1,41 @@
-import esbuild from 'esbuild';
+import fs from 'node:fs/promises';
 import path from 'node:path';
+import fg from 'fast-glob';
+import esbuild from 'esbuild';
 
-export const jsConfig = eleventyConfig => {
-  eleventyConfig.addTemplateFormats('js');
-
-  eleventyConfig.addExtension('js', {
-    outputFileExtension: 'js',
-    compile: async (content, inputPath) => {
-      // Skip processing if not in the designated scripts directories
-      if (!inputPath.startsWith('./src/assets/scripts/')) {
-        return;
-      }
-
-      // Inline scripts processing
-      if (inputPath.startsWith('./src/assets/scripts/bundle/')) {
-        const filename = path.basename(inputPath);
-        const outputFilename = filename;
-        const outputPath = `./src/_includes/scripts/${outputFilename}`;
-
-        await esbuild.build({
-          target: 'es2020',
-          entryPoints: [inputPath],
-          outfile: outputPath,
-          bundle: true,
-          minify: true
-        });
-        return;
-      }
-
-      // Default handling for other scripts, excluding inline scripts
-      return async () => {
-        let output = await esbuild.build({
-          target: 'es2020',
-          entryPoints: [inputPath],
-          bundle: true,
-          minify: true,
-          write: false
-        });
-
-        return output.outputFiles[0].text;
-      };
-    }
+export const buildJs = async (inputPath, outputPath) => {
+  const result = await esbuild.build({
+    target: 'es2020',
+    entryPoints: [inputPath],
+    bundle: true,
+    minify: true,
+    write: false
   });
+
+  const output = result.outputFiles[0].text;
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, output);
+
+  return output;
+};
+
+export const buildAllJs = async () => {
+  const tasks = [];
+
+  const inlineBundleFiles = await fg(['src/assets/scripts/bundle/*.js']);
+  for (const inputPath of inlineBundleFiles) {
+    const baseName = path.basename(inputPath);
+    const outputPath = `src/_includes/scripts/${baseName}`;
+    tasks.push(buildJs(inputPath, outputPath));
+  }
+
+  const componentFiles = await fg(['src/assets/scripts/components/*.js']);
+  for (const inputPath of componentFiles) {
+    const baseName = path.basename(inputPath);
+    const outputPath = `dist/assets/scripts/components/${baseName}`;
+    tasks.push(buildJs(inputPath, outputPath));
+  }
+
+  await Promise.all(tasks);
 };


### PR DESCRIPTION
Eleventy processes templates based on their dependency graph, not file type or extension order.
This means a Markdown file that includes a Nunjucks partial (e.g. a CSS or JS include) will trigger the rendering of that partial on demand. But it does not garantee that the build execution will be finished before a build of a template that rely on this resources.

esbuild and PostCSS can take longer than rendering Nunjucks or Markdown files, so the compiled assets may not be ready by the time the template needs them.

This PR extracts CSS and JS config processing logic out of Eleventy’s default compilation pipeline, and instead runs it manually in an `eleventy.before` hook. This ensures assets are available *before* any templates attempt to include them.

This avoids race conditions or empty asset includes during the build.

Changes:
- Moves all PostCSS and esbuild logic to `buildCss()` and `buildJs()` functions
- Adds a new `buildAllCss()` and `buildAllJs()` system
- Runs both in the `eleventy.before` lifecycle hook

Warning, this PR :
- Updates Eleventy to `"@11ty/eleventy": "^3.1.2"`
- Adds `fast-glob@^3.3.3` to devDependencies
