### PR TITLE
Add search page that uses pagefind to index and search content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "markdown-it-mark": "^4.0.0",
         "markdown-it-prism": "^3.0.0",
         "netlify-plugin-cache": "^1.0.3",
+        "pagefind": "^1.4.0",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
         "postcss-import": "^16.1.1",
@@ -1858,6 +1859,90 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4366,6 +4451,24 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "screenshots": "node ./src/_config/setup/generate-screenshots.js",
     "dev:11ty": "cross-env ELEVENTY_ENV=development eleventy --serve",
     "build:11ty": "cross-env ELEVENTY_ENV=production eleventy",
+    "build:search": "pagefind --site 'dist' --glob '**/*.html'",
     "start": "npm run dev:11ty",
-    "build": "npm run clean && npm run build:11ty"
+    "build": "npm run clean && npm run build:11ty && npm run build:search"
   },
   "keywords": [],
   "repository": {
@@ -57,6 +58,7 @@
     "markdown-it-mark": "^4.0.0",
     "markdown-it-prism": "^3.0.0",
     "netlify-plugin-cache": "^1.0.3",
+    "pagefind": "^1.4.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "postcss-import": "^16.1.1",

--- a/src/_data/navigation.js
+++ b/src/_data/navigation.js
@@ -15,6 +15,10 @@ export default {
     {
       text: 'Blog',
       url: '/blog/'
+    },
+    {
+      text: 'Search',
+      url: '/search/'
     }
   ],
   bottom: [

--- a/src/_includes/partials/date.njk
+++ b/src/_includes/partials/date.njk
@@ -1,1 +1,1 @@
-<time datetime="{{ definedDate | toIsoString }}"> {{ definedDate | formatDate('MMMM D, YYYY') }} </time>
+<time datetime="{{ definedDate | toIsoString }}" data-pagefind-meta="date"> {{ definedDate | formatDate('MMMM D, YYYY') }} </time>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -55,5 +55,11 @@
       <script type="module" src="/assets/scripts/components/custom-easteregg.js"></script>
       <custom-easteregg></custom-easteregg>
     {%- endif -%}
+
+    <!-- pagefind result highlighting -->
+    <script type="module">
+      await import('/pagefind/pagefind-highlight.js');
+      new PagefindHighlight({ highlightParam: "highlight" });
+    </script>
   </body>
 </html>

--- a/src/_layouts/page.njk
+++ b/src/_layouts/page.njk
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-<div class="region wrapper flow prose" style="--region-space-top: var(--space-xl-2xl)">
+<div class="region wrapper flow prose" style="--region-space-top: var(--space-xl-2xl)" data-pagefind-body data-pagefind-filter="type:Post" data-pagefind-meta="type:Post">
   <h1 class="gradient-text">{{ title }}</h1>
   {{ content | safe }}
 </div>

--- a/src/_layouts/page.njk
+++ b/src/_layouts/page.njk
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-<div class="region wrapper flow prose" style="--region-space-top: var(--space-xl-2xl)" data-pagefind-body data-pagefind-filter="type:Post" data-pagefind-meta="type:Post">
+<div class="region wrapper flow prose" style="--region-space-top: var(--space-xl-2xl)" data-pagefind-body data-pagefind-filter="type:Page" data-pagefind-meta="type:Page">
   <h1 class="gradient-text">{{ title }}</h1>
   {{ content | safe }}
 </div>

--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -4,7 +4,7 @@ schema: BlogPosting
 ---
 
 <div class="region" style="--region-space-top: var(--space-xl-2xl)">
-  <div class="wrapper flow prose">
+  <div class="wrapper flow prose" data-pagefind-body data-pagefind-filter="type:Post" data-pagefind-meta="type:Post">
     <h1 class="gradient-text">{{ title }}</h1>
 
     {% if image %}
@@ -37,7 +37,7 @@ schema: BlogPosting
   <!--  h-card infos: https://indieweb.org/authorship -->
   <div hidden class="h-entry">
     <a class="u-url" href="{{ page.url | url | absoluteUrl(meta.url) }}">{{ title }}</a>
-    <a class="p-name u-url" rel="author" href="{{ meta.url }}">{{ meta.author.name }}</a>
+    <a class="p-name u-url" rel="author" href="{{ meta.url }}" data-pagefind-meta="author">{{ meta.author.name }}</a>
     <img
       eleventy:ignore
       class="u-author h-card"

--- a/src/assets/css/local/forms.css
+++ b/src/assets/css/local/forms.css
@@ -11,6 +11,12 @@ form > * + * {
   background: var(--color-bg-accent);
   color: var(--color-text);
   width: 100%;
+  outline: 1px solid var(--focus-color, currentColor);
+  outline-offset: var(--focus-offset, 0.3ch);
+
+  &:focus-visible {
+    outline: 3px solid var(--focus-color, currentColor);
+  }
 
   &::placeholder {
     color: var(--color-mid);
@@ -37,7 +43,7 @@ label:has(input) {
 }
 
 label:has(input) + label:has(input) {
-  --flow-spce: var(--space-s-m);
+  --flow-space: var(--space-s-m);
 }
 
 /* Slightly adjusts the vertical position of the check/radio */
@@ -55,7 +61,7 @@ label input:disabled + * {
 }
 
 fieldset {
-  border: var(--stroke);
+  border: none;
   padding: var(--space-m);
 }
 

--- a/src/assets/css/local/search.css
+++ b/src/assets/css/local/search.css
@@ -1,0 +1,33 @@
+form#search {
+  .filter-and-results {
+    display: flex;
+    flex-direction: row;
+
+    &.filter-and-results--hidden {
+      display: none;
+    }
+
+    fieldset.types {
+      display: flex;
+      flex-direction: column;
+      width: fit-content;
+      font-size: smaller;
+    }
+
+    .results-area {
+      padding-right: 0.7em;
+    }
+  }
+}
+
+@media screen(ltsm) {
+  form#search {
+    .filter-and-results {
+      flex-direction: column;
+
+      .results-area {
+        padding-right: 0;
+      }
+    }
+  }
+}

--- a/src/assets/scripts/bundle/search.js
+++ b/src/assets/scripts/bundle/search.js
@@ -1,0 +1,178 @@
+const allTypes = ['Page', 'Post'];
+
+async function ensurePagefind() {
+  if (window.pagefind) return Promise.resolve(window.pagefind);
+  return import('/pagefind/pagefind.js')
+    .then(function (mod) {
+      mod.options({
+        highlightParam: 'highlight'
+      });
+      window.pagefind = mod;
+      return window.pagefind || mod.pagefind || mod.default || mod;
+    })
+    .catch(function () {
+      return new Promise(function (resolve) {
+        const s = document.createElement('script');
+        s.src = '/pagefind/pagefind.js';
+        s.type = 'module';
+        s.onload = function () {
+          resolve(window.pagefind);
+        };
+        s.onerror = function () {
+          resolve(undefined);
+        };
+        document.head.appendChild(s);
+      });
+    });
+}
+
+function renderItem(item) {
+  let {
+    url,
+    excerpt,
+    meta: {author, date, title, type}
+  } = item;
+
+  const dateText = date ? `<span slot="date">${date}</span>` : '';
+
+  let variant;
+  switch (type) {
+    case 'Page':
+      variant = 'secondary';
+      break;
+    default:
+      variant = 'primary';
+      break;
+  }
+
+  return `
+<custom-card clickable class="mt-s-m">
+  <h2 slot="headline" class="text-step-2">
+    <a href="${url}">${title}</a>
+  </h2>
+  ${dateText}
+  <div slot="type" webc:nokeep>
+    <span class="button" data-small-button data-button-variant=${variant}>${type}</span>
+  </div>
+  <div slot="content" webc:nokeep>${excerpt}</div>
+</custom-card>
+`;
+}
+
+function renderItems(q, items) {
+  var results = items.length == 1 ? 'result' : 'results';
+  document.querySelector('#results-count').innerHTML = `${items.length} ${results} for ${q}`;
+
+  let content = items.map(renderItem).join('');
+  document.querySelector('#results').innerHTML = content;
+}
+
+function doSearch(isPopEvent = false) {
+  let form = document.querySelector('form#search');
+
+  // Clear current content
+  document.querySelector('#results').innerHTML = '';
+  document.querySelector('#results-count').innerHTML = '';
+
+  // Get form data
+  let formData = new FormData(form);
+  let q = formData.get('q');
+
+  let types = [];
+  allTypes.map(possibleFilter => {
+    if (formData.get(possibleFilter)) {
+      types.push(possibleFilter);
+    }
+  });
+
+  // Only do a search if there's a query
+  if (q) {
+    // Update url unless it's a popstate event
+    if (!isPopEvent) {
+      setWindowLocation(q, types, isPopEvent);
+    }
+
+    // Show results area
+    form.querySelector('#filter-and-results').classList.remove('filter-and-results--hidden');
+
+    // Find and display results
+    window.pagefind
+      .search(q, {filters: {type: {any: types}}})
+      .then(search =>
+        Promise.all(search.results.map(result => result.data()))
+          .then(data => renderItems(q, data))
+          .catch(console.error)
+      )
+      .catch(console.error);
+  }
+}
+
+function setWindowLocation(q, types) {
+  const url = new URL(window.location);
+  if (q) {
+    url.searchParams.set('q', q);
+  }
+
+  url.searchParams.delete('types');
+  for (const type of types) {
+    url.searchParams.append('types', type);
+  }
+
+  window.history.pushState({search: url.searchParams.toString()}, '', url);
+}
+
+function setFormFromLocation() {
+  const url = new URL(window.location);
+  let searchParams = url.searchParams;
+  setFormFromSearchParams(searchParams);
+}
+
+function setFormFromSearchParams(searchParams) {
+  let q = searchParams.get('q');
+  document.querySelector('form#search input#q').value = q;
+
+  let types = searchParams.getAll('types');
+
+  for (const type of allTypes) {
+    document.querySelector(`form#search input[name="${type}"]`).checked = types.includes(type);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', _ => {
+  ensurePagefind()
+    .then(_ => {
+      setFormFromLocation();
+      doSearch();
+    })
+    .catch(e => console.error('page find error', e));
+
+  let form = document.querySelector('form#search');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+
+    doSearch();
+  });
+
+  // Submit form on post type change
+  let checkboxes = form.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('change', _ => {
+      doSearch();
+    });
+  });
+
+  // Using browser back or forward button
+  window.addEventListener('popstate', event => {
+    // Only intercept if on search page
+    if (!['/search/', '/search'].includes(window.location.pathname)) return;
+
+    ensurePagefind()
+      .then(_ => {
+        let searchParams = new URLSearchParams(event.state?.search ?? '');
+        setFormFromSearchParams(searchParams);
+        // Don't update history as we're navigating through history!
+        doSearch(true);
+      })
+      .catch(e => console.error('page find error', e));
+  });
+});

--- a/src/pages/search.njk
+++ b/src/pages/search.njk
@@ -1,0 +1,38 @@
+---
+title: Search
+permalink: /search/index.html
+description: 'Search the Eleventy Excellent website.'
+layout: page
+---
+
+<search>
+  <form role="search" action="https://duckduckgo.com" method="GET" id="search">
+    <fieldset>
+      <label for="q" class="hidden">Search</label>
+      <input id="q" type="search" name="q" placeholder="Search" autofocus>
+      <input type="hidden" name="sites" value="{{meta.domain}}">
+      <input type="submit" value="Search" class="hidden">
+    </fieldset>
+
+    <div class="filter-and-results filter-and-results--hidden" id="filter-and-results">
+      <fieldset class="types">
+        <label><input type="checkbox" name="Page">Page</label>
+        <label><input type="checkbox" name="Post">Post</label>
+      </fieldset>
+      <div class="results-area">
+        <header id="results-count"></header>
+        <div class="results" id="results"></div>
+      </div>
+    </div>
+  </form>
+</search>
+
+
+{% css "local" %}
+  {% include "css/forms.css" %}
+  {% include "css/search.css" %} 
+  {% include "css/custom-card.css" %}
+{% endcss %}
+{% js "defer" %}
+  {% include "scripts/search.js" %}
+{% endjs %} 


### PR DESCRIPTION
Adds a search page that uses [pagefind](https://pagefind.app/) to index and search content. Searches can be filtered by page type.

When searching the url is updated with the search parameters, and if the search page has params when initially loaded the search form is populated & the search is triggered.

If javascript is disabled, the form does a DuckDuckGo site search.