### PR TITLE
feat: generate llms.txt and make AI bot blocking configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ https://eleventy-excellent.netlify.app/
 - Automatically generated Open Graph images for blog posts _([see blog post](https://eleventy-excellent.netlify.app/blog/open-graph-images/))_
 - Tailwind CSS - but not how you might expect _([see blog post](https://eleventy-excellent.netlify.app/blog/what-is-tailwind-css-doing-here/))_
 - XML-sitemap
+- llms.txt, a machine-readable site summary for LLMs and AI agents, generated from your content
+- Configurable blocking of AI bots: training crawlers and on-demand agents, separately
 - dayjs handling dates & times
 - Bundling via esbuild
 - RSS feed (now you can add more than one)

--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -93,6 +93,15 @@ export const greenweb = {
   ],
   services: [{domain: 'netlify.com', serviceType: 'cdn'}]
 };
+export const robots = {
+  // Which AI bots are disallowed in robots.txt. The user agent lists are sourced from
+  // https://github.com/ai-robots-txt/ai.robots.txt and live in `src/common/robots.njk`.
+  // Bots that scrape your content for AI training and AI search indexes.
+  blockAiCrawlers: true,
+  // On-demand AI assistants and browsing agents, fetching a page because a user asked for it
+  // (e.g. ChatGPT-User, Claude-User, Operator). Set to false to allow agentic browsing on your site.
+  blockAiAgents: true
+};
 export const tests = {
   pa11y: {
     // keep customPaths empty if you want to test all pages

--- a/src/common/llms.njk
+++ b/src/common/llms.njk
@@ -1,0 +1,32 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+excludeFromSitemap: true
+---
+{#-
+  Machine-readable summary of this site for LLMs and AI agents,
+  following the llms.txt convention: https://llmstxt.org/
+  Checked by the "Agentic browsing" category in Lighthouse (Chrome 150+).
+-#}
+# {{ meta.siteName | safe }}
+
+> {{ meta.siteDescription | safe }}
+
+## Pages
+{% for page in collections.showInSitemap %}
+{%- if '/pages/' in page.inputPath and page.url and page.url != '/' and page.data.excludeFromSitemap != true %}
+{%- if not page.data.pagination or page.data.pagination.pageNumber == 0 %}
+- [{{ page.data.title | safe }}]({{ meta.url }}{{ page.url }}){% if page.data.description %}: {{ page.data.description | safe }}{% endif %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+
+## Blog
+{% for post in collections.allPosts %}
+- [{{ post.data.title | safe }}]({{ meta.url }}{{ post.url }}){% if post.data.description %}: {{ post.data.description | safe }}{% endif %}
+{%- endfor %}
+
+## Optional
+
+- [Sitemap]({{ meta.url }}/sitemap.xml): XML sitemap of all pages
+- [Atom feed]({{ meta.url }}/feed.xml): The latest blog posts as a feed

--- a/src/common/robots.njk
+++ b/src/common/robots.njk
@@ -3,91 +3,43 @@ permalink: /robots.txt
 eleventyExcludeFromCollections: true
 excludeFromSitemap: true
 ---
+{#-
+  AI bot user agents, sourced from https://github.com/ai-robots-txt/ai.robots.txt
+  They are split into two groups, each controlled by a flag in `meta.robots`:
+  - aiCrawlers: bots that scrape content for AI training and AI search indexes
+  - aiAgents: on-demand assistants and browsing agents that fetch a page because a user asked for it.
+    Allowing these makes your site usable for agentic browsing.
+-#}
+{%- set aiCrawlers = [
+  'AI2Bot', 'Ai2Bot-Dolma', 'aiHitBot', 'Amazonbot', 'Andibot', 'anthropic-ai', 'Applebot',
+  'Applebot-Extended', 'bedrockbot', 'Brightbot 1.0', 'Bytespider', 'CCBot', 'Claude-SearchBot',
+  'Claude-Web', 'ClaudeBot', 'cohere-ai', 'cohere-training-data-crawler', 'Cotoyogi', 'Crawlspace',
+  'Diffbot', 'EchoboxBot', 'FacebookBot', 'facebookexternalhit', 'Factset_spyderbot', 'FirecrawlAgent',
+  'FriendlyCrawler', 'Google-CloudVertexBot', 'Google-Extended', 'GoogleOther', 'GoogleOther-Image',
+  'GoogleOther-Video', 'GPTBot', 'iaskspider/2.0', 'ICC-Crawler', 'ImagesiftBot', 'img2dataset',
+  'ISSCyberRiskCrawler', 'Kangaroo Bot', 'meta-externalagent', 'Meta-ExternalAgent',
+  'MyCentralAIScraperBot', 'OAI-SearchBot', 'omgili', 'omgilibot', 'PanguBot', 'Panscient',
+  'panscient.com', 'PerplexityBot', 'PetalBot', 'PhindBot', 'Poseidon Research Crawler', 'QualifiedBot',
+  'QuillBot', 'quillbot.com', 'SBIntuitionsBot', 'Scrapy', 'SemrushBot', 'SemrushBot-BA', 'SemrushBot-CT',
+  'SemrushBot-OCOB', 'SemrushBot-SI', 'SemrushBot-SWA', 'Sidetrade indexer bot', 'TikTokSpider',
+  'Timpibot', 'VelenPublicWebCrawler', 'Webzio-Extended', 'wpbot', 'YandexAdditional',
+  'YandexAdditionalBot', 'YouBot'
+] -%}
+{%- set aiAgents = [
+  'ChatGPT-User', 'Claude-User', 'DuckAssistBot', 'Meta-ExternalFetcher', 'meta-externalfetcher',
+  'MistralAI-User/1.0', 'NovaAct', 'Operator', 'Perplexity-User'
+] -%}
 User-agent: *
 Disallow: /404.html
 
 Sitemap: {{ meta.url }}/sitemap.xml
-
-# https://github.com/ai-robots-txt/ai.robots.txt/blob/main/robots.txt
-
-User-agent: AI2Bot
-User-agent: Ai2Bot-Dolma
-User-agent: aiHitBot
-User-agent: Amazonbot
-User-agent: Andibot
-User-agent: anthropic-ai
-User-agent: Applebot
-User-agent: Applebot-Extended
-User-agent: bedrockbot
-User-agent: Brightbot 1.0
-User-agent: Bytespider
-User-agent: CCBot
-User-agent: ChatGPT-User
-User-agent: Claude-SearchBot
-User-agent: Claude-User
-User-agent: Claude-Web
-User-agent: ClaudeBot
-User-agent: cohere-ai
-User-agent: cohere-training-data-crawler
-User-agent: Cotoyogi
-User-agent: Crawlspace
-User-agent: Diffbot
-User-agent: DuckAssistBot
-User-agent: EchoboxBot
-User-agent: FacebookBot
-User-agent: facebookexternalhit
-User-agent: Factset_spyderbot
-User-agent: FirecrawlAgent
-User-agent: FriendlyCrawler
-User-agent: Google-CloudVertexBot
-User-agent: Google-Extended
-User-agent: GoogleOther
-User-agent: GoogleOther-Image
-User-agent: GoogleOther-Video
-User-agent: GPTBot
-User-agent: iaskspider/2.0
-User-agent: ICC-Crawler
-User-agent: ImagesiftBot
-User-agent: img2dataset
-User-agent: ISSCyberRiskCrawler
-User-agent: Kangaroo Bot
-User-agent: meta-externalagent
-User-agent: Meta-ExternalAgent
-User-agent: meta-externalfetcher
-User-agent: Meta-ExternalFetcher
-User-agent: MistralAI-User/1.0
-User-agent: MyCentralAIScraperBot
-User-agent: NovaAct
-User-agent: OAI-SearchBot
-User-agent: omgili
-User-agent: omgilibot
-User-agent: Operator
-User-agent: PanguBot
-User-agent: Panscient
-User-agent: panscient.com
-User-agent: Perplexity-User
-User-agent: PerplexityBot
-User-agent: PetalBot
-User-agent: PhindBot
-User-agent: Poseidon Research Crawler
-User-agent: QualifiedBot
-User-agent: QuillBot
-User-agent: quillbot.com
-User-agent: SBIntuitionsBot
-User-agent: Scrapy
-User-agent: SemrushBot
-User-agent: SemrushBot-BA
-User-agent: SemrushBot-CT
-User-agent: SemrushBot-OCOB
-User-agent: SemrushBot-SI
-User-agent: SemrushBot-SWA
-User-agent: Sidetrade indexer bot
-User-agent: TikTokSpider
-User-agent: Timpibot
-User-agent: VelenPublicWebCrawler
-User-agent: Webzio-Extended
-User-agent: wpbot
-User-agent: YandexAdditional
-User-agent: YandexAdditionalBot
-User-agent: YouBot
-Disallow: /
+{% if meta.robots.blockAiCrawlers %}
+# AI training and data scraper bots - https://github.com/ai-robots-txt/ai.robots.txt
+{% for bot in aiCrawlers %}User-agent: {{ bot }}
+{% endfor %}Disallow: /
+{% endif %}
+{%- if meta.robots.blockAiAgents %}
+# On-demand AI assistants and browsing agents
+{% for bot in aiAgents %}User-agent: {{ bot }}
+{% endfor %}Disallow: /
+{% endif %}

--- a/src/docs/ai-bots-and-agents.md
+++ b/src/docs/ai-bots-and-agents.md
@@ -1,0 +1,20 @@
+---
+title: AI bots and agents
+---
+
+AI bots visit your site for different reasons. Some scrape your content to train models or to fill AI search indexes. Others act on behalf of a single person: assistants and browsing agents that open a page because a user asked them to.
+
+You can decide which of them are allowed in `src/_data/meta.js`, within `robots`:
+
+- `blockAiCrawlers` disallows training and data scraper bots in `robots.txt`.
+- `blockAiAgents` disallows on-demand assistants and browsing agents (for example _ChatGPT-User_, _Claude-User_ or _Operator_). Set it to `false` if you want your site to be usable for [agentic browsing](https://developer.chrome.com/blog/agent-ready-toolkit).
+
+Both are `true` by default, so all known AI bots are blocked until you decide otherwise. The user agent lists live in `src/common/robots.njk` and are sourced from [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt).
+
+### llms.txt
+
+`src/common/llms.njk` generates an [llms.txt](https://llmstxt.org/) file at the root of your site: a markdown summary of your pages and blog posts, including their descriptions, built from your content on every build. LLMs and agents use it to understand what your site offers without crawling every page. Adjust the sections in the template if you want to highlight different content, or delete the file if you don't want to provide it.
+
+### Testing
+
+Lighthouse includes an [Agentic browsing](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) category from Chrome 150 on. It checks for a valid llms.txt file, visual stability and an expressive accessibility tree - the primary data model agents use to interact with a page. Since this starter takes accessibility seriously, you are already in good shape. You can also let your coding agent test your site in a real browser with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp).


### PR DESCRIPTION
Chrome's Lighthouse now ships an [Agentic browsing category](https://developer.chrome.com/blog/agent-ready-toolkit) that checks how well a site works for AI agents acting on a user's behalf. Eleventy Excellent already nails the two hard parts (accessibility tree, layout stability), this PR adds the 2 missing pieces, without changing any default behavior.

**llms.txt**  `src/common/llms.njk` generates a markdown site summary at `/llms.txt` , built from pages and posts with their descriptions, following the same pattern as `robots.njk` and `humans.txt`. Delete the template if you don't want the file.

**Configurable AI bot blocking**  `robots.njk` still uses the [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt) list, now split into two groups toggled from `meta.js`: bots scraping for AI training/search indexes, and on-demand assistants/agents (ChatGPT-User, Claude-User, Operator, …). **Both flags default to `true`, so the generated robots.txt disallows exactly the same 80 user agents as today**  users who want agentic browsing opt in with one flag.

Also adds a docs page ("AI bots and agents") and 2 readme bullets.

**Verified:** Lighthouse 13.4.1 Agentic Browsing scores 1.0 on `/` and on the image post (`llms-txt` audit passes, CLS 0); all 4 flag combinations produce correct robots.txt; `npm run test:a11y` results identical to `main`; prettier clean on changed files.