### PR TITLE
fix: feed updated date and relative urls in the json feedFix/feeds

### DIFF
--- a/src/common/feed-atom.njk
+++ b/src/common/feed-atom.njk
@@ -3,6 +3,7 @@ permalink: /feed.xml
 eleventyExcludeFromCollections: true
 excludeFromSitemap: true
 ---
+{%- set postslist = collections.posts -%}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ meta.lang or page.lang }}" xml:base="{{ meta.url }}/">
   <title>{{ meta.blog.name }}</title>
@@ -14,7 +15,6 @@ excludeFromSitemap: true
   <author>
     <name>{{ meta.author.name }}</name>
   </author>
-	{% set postslist = collections.posts %}
   {%- for post in postslist | reverse -%}
   {%- set absolutePostUrl = post.url | absoluteUrl(meta.url) -%}
     <entry>

--- a/src/common/feed-json.njk
+++ b/src/common/feed-json.njk
@@ -23,7 +23,7 @@ excludeFromSitemap: true
       "id": "{{ absolutePostUrl }}",
       "url": "{{ absolutePostUrl }}",
       "title": "{{ post.data.title }}",
-      "content_html": {% if post.content %}{{ post.content | renderTransforms(post.data.page, metadata.base) | dump | safe }}{% else %}""{% endif %},
+      "content_html": {% if post.content %}{{ post.content | renderTransforms(post.data.page, meta.url) | dump | safe }}{% else %}""{% endif %},
       "date_published": "{{ post.date | dateToRfc3339 }}"
     }
     {% if not loop.last %},{% endif %}


### PR DESCRIPTION
I noticed 2 small bugs in the generated feeds.

In feed.xml, the `<updated>` element is rendered before `{% set postslist %}` is reached, so it always falls back to the build time. You can see it on the demo site, the feed says it was updated on the last deploy date, but the newest post is from January 2025. Moving the set line up fixes it.

In feed.json, `content_html` passes `metadata.base` to `renderTransforms`, but the global is called `meta`, so the base is always undefined and the links in the feed stay relative, which breaks them in feed readers. The atom feed already passes `meta.url`, so the json feed now does the same.

After the change the built feed.xml has `<updated>2025-01-11</updated>` and feed.json only contains absolute urls.