### PR TITLE
fix: accessible names, list semantics and details history

### DIFF
--- a/src/_includes/partials/details.njk
+++ b/src/_includes/partials/details.njk
@@ -1,9 +1,9 @@
 {% set headingLevel = headingLevel | default(false) %}
 
 <div class="details flow">
-  <div class="control | cluster" aria-label="{{ meta.details.aria }}">
-    <button id="expandAll" class="button" data-small-button>{{ meta.details.expand }}</button>
-    <button id="collapseAll" class="button" data-small-button>{{ meta.details.collapse }}</button>
+  <div class="control | cluster" role="group" aria-label="{{ meta.details.aria }}">
+    <button data-expand-all class="button" data-small-button>{{ meta.details.expand }}</button>
+    <button data-collapse-all class="button" data-small-button>{{ meta.details.collapse }}</button>
   </div>
   {%- for item in itemList | alphabetic -%}
     <details id="{{ item.data.title | slugify }}">

--- a/src/_includes/partials/gallery.njk
+++ b/src/_includes/partials/gallery.njk
@@ -1,5 +1,5 @@
 <is-land on:idle>
-  <div class="gallery | grid mt-l-xl gutter-xs" role="list">
+  <div class="gallery | grid mt-l-xl gutter-xs">
     {%- for item in gallery -%}
       <dialog class="flow modal{{ loop.index }}">
         <div class="cluster justify-center flow-space-m gutter-s">

--- a/src/_includes/partials/main-nav.njk
+++ b/src/_includes/partials/main-nav.njk
@@ -7,12 +7,7 @@
     {% for item in navigation.top %}
       {% if item.submenu %}
         <li class="relative">
-          <button
-            data-submenu-toggle
-            aria-expanded="false"
-            aria-labelledby="mainnav-{{ loop.index }}"
-            aria-controls="mainnav-{{ loop.index }}-sub"
-          >
+          <button data-submenu-toggle aria-expanded="false" aria-controls="mainnav-{{ loop.index }}-sub">
             {{ item.text }} {% svg "misc/chev-down" %}
           </button>
           <ul class="nav-sublist | cluster" id="mainnav-{{ loop.index }}-sub">

--- a/src/assets/scripts/bundle/details.js
+++ b/src/assets/scripts/bundle/details.js
@@ -1,25 +1,26 @@
-const container = document.querySelector('.details');
-const expandAllButton = container.querySelector('#expandAll');
-const collapseAllButton = container.querySelector('#collapseAll');
-const details = container.querySelectorAll('details');
+document.querySelectorAll('.details').forEach(container => {
+  const expandAllButton = container.querySelector('[data-expand-all]');
+  const collapseAllButton = container.querySelector('[data-collapse-all]');
+  const details = container.querySelectorAll('details');
 
-expandAllButton.addEventListener('click', () => {
-  details.forEach(detail => (detail.open = true));
-});
+  expandAllButton.addEventListener('click', () => {
+    details.forEach(detail => (detail.open = true));
+  });
 
-collapseAllButton.addEventListener('click', () => {
-  details.forEach(detail => (detail.open = false));
-});
+  collapseAllButton.addEventListener('click', () => {
+    details.forEach(detail => (detail.open = false));
+  });
 
-details.forEach(detail => {
-  detail.addEventListener('toggle', () => {
-    const hash = detail.open ? `#${detail.id}` : '#';
-    history.pushState(null, null, hash);
+  details.forEach(detail => {
+    detail.addEventListener('toggle', () => {
+      const hash = detail.open ? `#${detail.id}` : '#';
+      history.replaceState(null, '', hash);
+    });
   });
 });
 
 const id = window.location.hash.slice(1);
 if (id) {
-  const detail = container.querySelector(`#${CSS.escape(id)}`);
+  const detail = document.querySelector(`.details #${CSS.escape(id)}`);
   if (detail) detail.open = true;
 }

--- a/src/pages/styleguide.njk
+++ b/src/pages/styleguide.njk
@@ -58,7 +58,9 @@ customGradients:
         <a href="#" class="button" data-small-button>small button</a>
       </li>
       <li>
-        <a href="#" class="button" data-icon>{% svg "misc/star" %}</a>
+        <a href="#" class="button" data-icon
+          ><span class="visually-hidden">Icon button</span>{% svg "misc/star" %}</a
+        >
       </li>
     </ul>
   </section>


### PR DESCRIPTION
**The styleguide fails `npm run test:a11y` on main** — the icon-only star button
is an `<a>` containing nothing but an inline SVG, so it exposes no accessible
name. pa11y-ci reports *"Anchor element found with a valid href attribute, but no
link content has been supplied"* and the run exits 3/4. Added a `visually-hidden`
span, the same pattern the gallery dialog buttons already use; the suite then
passes 4/4.

**List role without list items**  the gallery wrapper carries `role="list"`, but
its children are `<dialog>` and `<button>` elements, never list items, so
assistive technology announces a list with nothing in it. Removed the role; the
grid stays a plain container.

**Details component history** toggling a `<details>` called
`history.pushState`, so every open and close added a history entry and the back
button walked through toggle states instead of leaving the page. That is now
`replaceState`. The same commit scopes the expand/collapse buttons to their own
`.details` container and swaps their ids for data attributes, so including the
partial more than once on a page keeps working that part is robustness, not a
bug today, since the partial is used once per page.

**Dangling label reference on the submenu toggle** `main-nav.njk` labels the
submenu button with `aria-labelledby="mainnav-{{ loop.index }}"`, but no element
with that id exists: the ids in the file are `mainnav` on the `<nav>` and
`mainnav-{{ loop.index }}-sub` on the submenu list. This only shows up when
`meta.navigation.subMenu` is enabled, which is off in the default config.
Removing the attribute lets the name come from the button text, which is what it
was meant to be.

**Verified:** `npm run test:a11y` goes from 3/4 to 4/4 URLs passing. The other
three fixes are outside the default pa11y scope the submenu is behind a flag,
and the gallery and details pages are not in the sitemap collection pa11y walks so those rest on the markup analysis above rather than on a failing test.