### PR TITLE
fix: cdn dependency, leaking listeners and blocked storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "@11ty/eleventy-plugin-webc": "^0.11.2",
         "@11ty/is-land": "^4.0.1",
+        "canvas-confetti": "^1.9.4",
         "lite-youtube-embed": "^0.3.4",
         "tailwindcss": "^3.4.17"
       },
@@ -1109,9 +1110,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1127,9 +1125,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1147,9 +1142,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1165,9 +1157,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1185,9 +1174,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1203,9 +1189,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1223,9 +1206,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1242,9 +1222,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1260,9 +1237,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1286,9 +1260,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1310,9 +1281,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1336,9 +1304,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1360,9 +1325,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1386,9 +1348,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1411,9 +1370,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1435,9 +1391,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2316,6 +2269,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/check-types": {
       "version": "11.2.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "@11ty/eleventy-plugin-webc": "^0.11.2",
     "@11ty/is-land": "^4.0.1",
+    "canvas-confetti": "^1.9.4",
     "lite-youtube-embed": "^0.3.4",
     "tailwindcss": "^3.4.17"
   },

--- a/src/assets/scripts/bundle/theme-toggle.js
+++ b/src/assets/scripts/bundle/theme-toggle.js
@@ -8,7 +8,7 @@ const theme = {
   value: getColorPreference()
 };
 
-window.onload = () => {
+window.addEventListener('load', () => {
   const lightThemeToggle = document.querySelector('#light-theme-toggle');
   const darkThemeToggle = document.querySelector('#dark-theme-toggle');
   const switcher = document.querySelector('[data-theme-switcher]');
@@ -25,12 +25,12 @@ window.onload = () => {
 
   lightThemeToggle.setAttribute('aria-pressed', theme.value === 'light');
   darkThemeToggle.setAttribute('aria-pressed', theme.value === 'dark');
-};
+});
 
-// sync with system changes
+// sync with system changes, without storing them as an explicit choice
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({matches: isDark}) => {
   theme.value = isDark ? 'dark' : 'light';
-  setPreference();
+  reflectPreference();
   updateMetaThemeColor();
 });
 
@@ -42,16 +42,27 @@ function onClick(themeValue) {
   updateMetaThemeColor();
 }
 
-function getColorPreference() {
-  if (localStorage.getItem(storageKey)) {
+function getStoredPreference() {
+  // storage can be blocked entirely, the toggle should still work
+  try {
     return localStorage.getItem(storageKey);
-  } else {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  } catch (error) {
+    return null;
   }
 }
 
+function getColorPreference() {
+  return (
+    getStoredPreference() || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  );
+}
+
 function setPreference() {
-  localStorage.setItem(storageKey, theme.value);
+  try {
+    localStorage.setItem(storageKey, theme.value);
+  } catch (error) {
+    // not persisted, but the current page still reflects the choice
+  }
   reflectPreference();
   updateMetaThemeColor();
 }

--- a/src/assets/scripts/components/custom-easteregg.js
+++ b/src/assets/scripts/components/custom-easteregg.js
@@ -13,14 +13,15 @@ class customEasteregg extends HTMLElement {
     this.particleCount = parseInt(this.getAttribute('particle-count'), 10) || 30;
     this.codes = this.keywords.map(keyword => keyword.split(''));
     this.indexes = new Array(this.keywords.length).fill(0);
+    this.handleKeydown = this.handleKeydown.bind(this);
   }
 
   connectedCallback() {
-    document.addEventListener('keydown', this.handleKeydown.bind(this));
+    document.addEventListener('keydown', this.handleKeydown);
   }
 
   disconnectedCallback() {
-    document.removeEventListener('keydown', this.handleKeydown.bind(this));
+    document.removeEventListener('keydown', this.handleKeydown);
   }
 
   handleKeydown(event) {
@@ -40,7 +41,7 @@ class customEasteregg extends HTMLElement {
 
   triggerEffect(keyword) {
     console.log(`Hooray ${keyword}!`);
-    import('https://esm.run/canvas-confetti').then(({default: confetti}) => {
+    import('canvas-confetti').then(({default: confetti}) => {
       const scalar = 4;
       const customShape = confetti.shapeFromText({text: this.shape, scalar});
 

--- a/src/assets/scripts/components/custom-masonry.js
+++ b/src/assets/scripts/components/custom-masonry.js
@@ -2,13 +2,14 @@ class CustomMasonry extends HTMLElement {
   constructor() {
     super();
     this.layoutMasonry = this.layoutMasonry.bind(this);
+    this.debounceLayout = this.debounceLayout.bind(this, 100);
   }
 
   connectedCallback() {
     // Defer initial layout to ensure styles are applied
     requestAnimationFrame(() => {
       this.layoutMasonry();
-      window.addEventListener('resize', this.debounceLayout.bind(this, 100));
+      window.addEventListener('resize', this.debounceLayout);
     });
   }
 


### PR DESCRIPTION
3 independent fixes to the client scripts, one commit each.

**canvas-confetti is fetched from a CDN at runtime** `custom-easteregg.js` calls
`import('https://esm.run/canvas-confetti')`, so every visitor who triggers the easter
egg pulls code from a third party. That is a request the site owner cannot audit, a
hard dependency on esm.run staying available, and something a European site owner has
to account for in a privacy notice.

It also cannot be pinned. `integrity` applies to `<script src>` and `<link>` only,
never to a dynamic `import()`, so there is no way to verify what that URL returns today or after someone else takes over the package. Bundling is the only fix available here.

The package is now a dependency and esbuild inlines it. The library was already in
use, only the delivery changes, and the built site no longer references any external
origin.

**Listeners are never removed** both custom elements call
`removeEventListener(..., this.handler.bind(this))` in `disconnectedCallback`. `bind`
returns a new function on every call, so that reference never matches the one
`addEventListener` received and the listener stays attached for the life of the page.
Binding once in the constructor makes the removal actually work.

**The theme toggle breaks when storage is blocked** `localStorage` throws rather
than returning null when a browser blocks it: Safari in lockdown mode, Firefox with
cookies disabled for the site, some embedded webviews. The unguarded read threw before
the toggle was wired up, leaving those visitors without a working theme switch. Access
is guarded now, and the choice still applies to the current page even when it cannot be persisted.

The same commit stops a system theme change from being recorded as a manual choice. It
called `setPreference()`, which wrote to storage, so a visitor whose OS switched to
dark at sunset was treated as having picked dark by hand and the site stopped following
the system from then on. It only reflects the change now. `window.onload =` also became
`addEventListener`, so the script no longer overwrites another load handler.

**Verified:** the built site contains no reference to `esm.run`, and the confetti
library is inlined in the bundled component. Easter egg, theme toggle and masonry
behave as before.