### PR TITLE
fix: web app manifest id and credentialed fetch

### DIFF
--- a/src/_includes/head/meta-info.njk
+++ b/src/_includes/head/meta-info.njk
@@ -89,4 +89,5 @@
 <link rel="icon" href="{{ '/favicon.ico' | url }}" sizes="any" />
 <link rel="icon" href="{{ '/favicon.svg' | url }}" type="image/svg+xml" />
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | url }}" />
-<link rel="manifest" href="{{ '/site.webmanifest' | url }}" />
+<!-- use-credentials: the manifest is fetched without cookies by default, which fails on password protected sites -->
+<link rel="manifest" href="{{ '/site.webmanifest' | url }}" crossorigin="use-credentials" />

--- a/src/common/site-manifest.njk
+++ b/src/common/site-manifest.njk
@@ -4,6 +4,7 @@ eleventyExcludeFromCollections: true
 excludeFromSitemap: true
 ---
 {
+  "id": "/",
   "name": "{{ meta.siteName }} - {{ meta.siteDescription }}",
   "short_name": "{{ meta.siteName }}",
   "start_url": "{{ meta.url }}",


### PR DESCRIPTION
2 small corrections to the web app manifest, one commit each. No new file, no
dependency, 3 lines in total.

**The manifest has no `id`** when the field is absent,
[the spec](https://www.w3.org/TR/appmanifest/#id-member) derives the application
identity from `start_url`. Since `start_url` is built from `meta.url`, anyone who moves
their site or changes that value orphans every existing installation: the installed app
stops matching and a second one appears alongside it. `"id": "/"` pins the identity to
the origin and stays stable whatever `start_url` becomes.

**The manifest is fetched without credentials** `<link rel="manifest">` is fetched
with credentials omitted unless the link says otherwise, so any site behind
authentication answers 401 and the browser retries. That covers Netlify and Vercel
password protection, staging environments and intranets, where the manifest silently
never loads and the site cannot be installed.

I hit this on a password protected Netlify deploy of this starter: seven
`site.webmanifest` requests, all 401. `crossorigin="use-credentials"` fixes it and
changes nothing on a public site, where the request is same origin either way.

**Verified:** manifest output is unchanged apart from the added field, and the
generated `<link>` is valid on a public deploy.