### PR TITLE
fix: incorrect paths in the docs and typos in the default texts

### DIFF
--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -30,11 +30,11 @@ export const themeLight = '#f8f8f8'; // used for meta tag theme-color, if light 
 export const themeDark = '#2e2e2e'; // used for meta tag theme-color, if dark colors are prefered. best use value set for dark bg
 export const opengraph_default = '/assets/images/template/opengraph-default.jpg'; // fallback/default meta image
 export const opengraph_default_alt =
-  "Visible content: An Eleventy starter with CUBE CSS, Cube CSS, Every Layout, Design Tokens and Tailwind for uitility classes. A workflow for building modern and resilient websites, introduced by Andy Bell's project buildexcellentwebsit.es"; // alt text for default meta image"
+  "Visible content: An Eleventy starter with CUBE CSS, Every Layout, Design Tokens and Tailwind for utility classes. A workflow for building modern and resilient websites, introduced by Andy Bell's project buildexcellentwebsit.es"; // alt text for default meta image
 export const blog = {
   // RSS feed
   name: 'My Web Development Blog',
-  description: 'Tell the word what you are writing about in your blog. It will show up on feed readers.',
+  description: 'Tell the world what you are writing about in your blog. It will show up in feed readers.',
   // feed links are looped over in the head. You may add more to the array.
   feedLinks: [
     {

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -10,7 +10,7 @@ I like to divide things into small thematic areas, it helps me orient myself bet
 - **plugins.js**: Everything I or Eleventy considers to be a plugin: https://www.11ty.dev/docs/plugins/
 - **shortcodes.js**: Defines shortcodes for reusable content: https://www.11ty.dev/docs/shortcodes/
 
-Each configuration category (filters, plugins, shortcodes, etc.) is modularized. or example, `dates.js` within the `filters` folder contains date-related filters.
+Each configuration category (filters, plugins, shortcodes, etc.) is modularized. For example, `dates.js` within the `filters` folder contains date-related filters.
 
 ```js
 import dayjs from 'dayjs';

--- a/src/docs/css.md
+++ b/src/docs/css.md
@@ -10,9 +10,9 @@ The CSS system of this starter was invented by Andy Bell. If you want to know ex
 
 ### Inline CSS and bundles
 
-The main CSS file is now inline in production to improve performance, see `.src/_includes/head/css-inline.njk`.
+The main CSS file is now inline in production to improve performance, see `src/_includes/head/css-inline.njk`.
 
-You can add per-page or component bundles of CSS. Instead of adding your CSS file to the `src/assets/css/global/blocks/` directory, you can place them in `src/assets/css/local/`. All CSS files in there will be stored alongside `global.css` in `.src/_includes/css/`. You can now include them in the "local" bundle only on pages or components where you need them:
+You can add per-page or component bundles of CSS. Instead of adding your CSS file to the `src/assets/css/global/blocks/` directory, you can place them in `src/assets/css/local/`. All CSS files in there will be stored alongside `global.css` in `src/_includes/css/`. You can now include them in the "local" bundle only on pages or components where you need them:
 
 {% raw %}
 

--- a/src/docs/javascript.md
+++ b/src/docs/javascript.md
@@ -4,7 +4,7 @@ title: JavaScript
 
 This starter has **no real JS dependency**. If JavaScript is not available, components that rely on it -- like the theme switcher -- will be hidden. If you opted in for the drawer menu, pills will be shown instead.
 
-There are two kinds of bundles for JavaScript in this starter, see `.src/_includes/head/js-inline.njk` and `.src/_includes/head/js-defer.njk`.
+There are two kinds of bundles for JavaScript in this starter, see `src/_includes/head/js-inline.njk` and `src/_includes/head/js-defer.njk`.
 By default, I include Eleventy's [is-land](https://github.com/11ty/is-land) framework and the theme toggle inline.
 
 You can include more scripts like so:
@@ -31,6 +31,6 @@ Same goes for scripts that should be defered:
 
 {% endraw %}
 
-Scripts stored in `src/assets/scripts/components/` are sent to the output folder, while scripts in  `src/assets/scripts/bundle/` are sent to `.src/_includes/scripts/`, from where you can include them in the respective bundle.
+Scripts stored in `src/assets/scripts/components/` are sent to the output folder, while scripts in  `src/assets/scripts/bundle/` are sent to `src/_includes/scripts/`, from where you can include them in the respective bundle.
 
 Some components are enhanced with JavaScript.

--- a/src/docs/open-graph.md
+++ b/src/docs/open-graph.md
@@ -28,9 +28,9 @@ If you want to be inspired, have a look at [what Lea is doing here.](https://lea
 
 Consider that the domain is a hard coded value in the front matter.
 
-**Important:** I have relocated the creation of the images in the development process, so that the font only needs to be installed on your own system. The images are located in `src/assets/og-images` and are comitted.
+**Important:** I have relocated the creation of the images in the development process, so that the font only needs to be installed on your own system. The images are located in `src/assets/og-images` and are committed.
 
-This is fine as long as you only work locally with Markdown, and the font is always installed on your system. If you work with a CMS you must add the font cto where the site is built. Some CMS let you add fonts into the `prebuild` config. Otherwise it usually falls down to the _Ubuntu_ Font Family. You still have to adjust the script `src/_config/events/svg-to-jpeg.js` to something like:
+This is fine as long as you only work locally with Markdown, and the font is always installed on your system. If you work with a CMS you must add the font to where the site is built. Some CMS let you add fonts into the `prebuild` config. Otherwise it usually falls down to the _Ubuntu_ Font Family. You still have to adjust the script `src/_config/events/svg-to-jpeg.js` to something like:
 
 ```js
 import fs from 'fs';

--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -2,17 +2,17 @@
 title: Pagination
 ---
 
-The blog posts use [Eleventy's pagination feature](https://www.11ty.dev/docs/pagination/). The logic for this can be found in tha partial `src/_includes/partials/pagination.njk`, the layout `src/_layouts/blog.njk` includes it, how many entries should be on a page is defined in `src/pages/blog.md`.
+The blog posts use [Eleventy's pagination feature](https://www.11ty.dev/docs/pagination/). The logic for this can be found in the partial `src/_includes/partials/pagination.njk`. The blog page `src/pages/blog.njk` includes it and defines how many entries should be on a page.
 
 If you do not want any pagination at all, it is easiest to set a very high number for the pagination size, for example:
 
 ```yaml
 pagination:
-  data: collections.posts
+  data: collections.allPosts
   size: 10000
 ```
 
-In `src/_data_/meta.js` you can set some values for the visible content (previous / next buttons) and the aria labels.
+In `src/_data/meta.js` you can set some values for the visible content (previous / next buttons) and the aria labels.
 
 You can also **hide the number fields** between the previous and next buttons by setting `paginationNumbers` to `false`.
 
@@ -27,14 +27,14 @@ blog: {
 }
 ```
 
-If you want to change the collection that is paginated (by default `collections.posts`), you must do so in two places: the front matter of the template, `src/pages/blog.md`:
+If you want to change the collection that is paginated (by default `collections.allPosts`), you must do so in two places: the front matter of the template, `src/pages/blog.njk`:
 
 ```yaml
 pagination:
-  data: collections.posts
+  data: collections.allPosts
 ```
 
-and where the pagination component is included: `src/_layouts/blog.njk`:
+and where the pagination component is included, further down in `src/pages/blog.njk`:
 
 {% raw %}
 

--- a/src/docs/svg.md
+++ b/src/docs/svg.md
@@ -18,7 +18,7 @@ The `svg.js` shortcode, introduced in version 3, allows for the seamless inclusi
 
 {% svg "misc/star", "A yellow star icon", "spin", "block-size: 4ex; fill: var(--color-tertiary);" %}
 
-The star icon resoves to:
+The star icon resolves to:
 
 `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" viewBox="0 0 24 24" aria-label="A yellow star icon" style="block-size: 4ex; fill: var(--color-tertiary)" class="spin"><path> (...) </path></svg>`
 

--- a/src/docs/tests.md
+++ b/src/docs/tests.md
@@ -4,7 +4,7 @@ title: Tests
 
 You can run local automated accessibility tests with [pa11y-ci](https://github.com/pa11y/pa11y-ci).
 
-`src/common/pa11y.njk` generates a _pa11y-ci_ config file for all pages in the sitemap by default. You can also define custom paths to test in `src/_data/meta.js`, whithin `tests.pa11y.customPaths`.
+`src/common/pa11y.njk` generates a _pa11y-ci_ config file for all pages in the sitemap by default. You can also define custom paths to test in `src/_data/meta.js`, within `tests.pa11y.customPaths`.
 
 To run the tests, use the following command:
 

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -1,7 +1,7 @@
 ---
 title: About
 permalink: /about/index.html
-description: 'Eleventy Excellent is inspired bythe companion website of Andy Bell’s talk "Be the browser’s mentor, not its micromanager".'
+description: 'Eleventy Excellent is inspired by the companion website of Andy Bell’s talk "Be the browser’s mentor, not its micromanager".'
 layout: page
 ---
 

--- a/src/posts/2022/2022-08-17-post-with-fetched.md
+++ b/src/posts/2022/2022-08-17-post-with-fetched.md
@@ -1,7 +1,7 @@
 ---
 title: 'Post with fetched content'
 description: 'Eleventy Fetch fetches and caches resources - at configurable intervals. In this example I am fetching my public repositories with a cache duration of 1 day.'
-date: 2022-08-28
+date: 2022-08-17
 tags: ['fetch', 'feature']
 ---
 

--- a/src/posts/2024/2024-02-01-v-2.md
+++ b/src/posts/2024/2024-02-01-v-2.md
@@ -1,6 +1,6 @@
 ---
 title: 'Eleventy Excellent 2.0'
-description: I created this starter after I saw Andy’s talk and studied the source code for **buildexcellentwebsit.es.** I quickly came to the conclusion that this is the way I want to build all my websites from now on! It's so great. I know many of you feel the same way.'
+description: I created this starter after I saw Andy’s talk and studied the source code for **buildexcellentwebsit.es.** I quickly came to the conclusion that this is the way I want to build all my websites from now on! It's so great. I know many of you feel the same way.
 discover:
   description: "I used markdown Syntax in the description, this is why I set this other description to be used in the meta description and the blog schema."
 date: 2024-02-01


### PR DESCRIPTION
Mostly typos, but the pagination page is actually wrong.

It tells you to paginate over `collections.posts`. That collection doesn't exist, it's
registered as `allPosts` in `collections.js`, which is what `blog.njk` uses too. Follow
that page and you get an empty blog. It also points at `src/pages/blog.md` for the page
size, but the file is `blog.njk`.

While I was in there I fixed the paths with a leading dot, `.src/_includes/…`, 4 of
them across the CSS and JS docs, plus a stray underscore in `src/_data_/meta.js`. You
can't copy any of those.

The typos in `meta.js` bothered me more than the ones in the docs, because they ship.
`blog.description` says "Tell the word what you are writing about", and that ends up in
the feed of every site built from the starter. Same for "CUBE CSS, Cube CSS" and
"uitility classes" in the default og alt text.

2 odds and ends: the fetched content demo post says `2022-08-28` in its front matter
while the filename says the 17th, and the 2.0 post description ends on a quote that
never opened.

No rewording anywhere, I only touched what was wrong.