### PR TITLE
feat: view transitions and prefetch on intent

### DIFF
--- a/src/_includes/head/speculation-rules.njk
+++ b/src/_includes/head/speculation-rules.njk
@@ -1,0 +1,13 @@
+<!-- Prefetches likely next pages on link hover / interaction. Progressive enhancement:
+     supported in chromium browsers, everyone else ignores the script block.
+     https://developer.chrome.com/docs/web-platform/prerender-pages -->
+<script type="speculationrules">
+  {
+    "prefetch": [
+      {
+        "where": {"href_matches": "/*"},
+        "eagerness": "moderate"
+      }
+    ]
+  }
+</script>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -38,6 +38,9 @@
 
     <!-- 8 meta tags, icons, open graph etc.  -->
     {% include "head/meta-info.njk" %}
+
+    <!-- 9 speculative prefetching, chromium only -->
+    {% include "head/speculation-rules.njk" %}
   </head>
 
   <body class="{{ layout }}">

--- a/src/assets/css/global/base/view-transitions.css
+++ b/src/assets/css/global/base/view-transitions.css
@@ -1,0 +1,9 @@
+/* Animates navigations between pages in browsers that support cross document
+   view transitions, everyone else keeps instant navigation.
+   https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API */
+
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
+}

--- a/src/assets/css/global/global.css
+++ b/src/assets/css/global/global.css
@@ -7,6 +7,7 @@
 
 @import 'base/variables.css' layer(variables);
 @import 'base/global-styles.css' layer(global);
+@import 'base/view-transitions.css' layer(global);
 
 @import-glob 'compositions/*.css' layer(compositions);
 @import-glob 'blocks/*.css' layer(blocks);


### PR DESCRIPTION
2 platform features, both progressive enhancement. 26 lines, nothing removed, no
dependencies.

**View transitions between pages.** `@view-transition { navigation: auto }` in a new
`base/view-transitions.css`. Browsers that support it cross-fade between pages, the rest
navigate instantly like they do today. It sits inside `prefers-reduced-motion, 
no-preference`, so anyone who asked for less motion gets none of it without having to
configure anything.

**Prefetch on intent.** A `speculationrules` block in the head, `eagerness: moderate`.
Chromium starts fetching a page when you hover a link or press the pointer down, not on
page load, so it's a few requests for links someone is about to click rather than a
crawl of the whole site.

Both are Chromium-only today, I'd rather say that plainly than oversell it. Everyone
else ignores the script block and keeps the navigation they have now.

Neither adds anything to maintain, no dependency, no config, no JavaScript. Removing
them later is deleting one CSS file and one include.

The part I'm least sure about is the eagerness. I went with `moderate` because `eager`
felt rude on a blog, but `conservative` waits for pointerdown only and you might prefer
that. Happy to change it, or to drop the speculation commit and keep just the
transitions if that's the half you want.