### PR TITLE
fix: keep animated images animated

### DIFF
--- a/src/_config/shortcodes/image.js
+++ b/src/_config/shortcodes/image.js
@@ -50,7 +50,9 @@ const processImage = async options => {
     }
   });
 
-  const lowsrc = metadata.jpeg[metadata.jpeg.length - 1];
+  // fall back to the last requested format when jpeg is not among them
+  const lowsrcFormat = metadata.jpeg || Object.values(metadata).pop();
+  const lowsrc = lowsrcFormat[lowsrcFormat.length - 1];
 
   const imageSources = Object.values(metadata)
     .map(imageFormat => {

--- a/src/_config/shortcodes/image.js
+++ b/src/_config/shortcodes/image.js
@@ -1,5 +1,19 @@
 import Image from '@11ty/eleventy-img';
+import sharp from 'sharp';
 import path from 'node:path';
+
+// avif and jpeg cannot carry an animation
+const animatedFormats = ['webp', 'gif'];
+
+const isAnimated = async src => {
+  try {
+    const {pages} = await sharp(src).metadata();
+    return pages > 1;
+  } catch {
+    // unreadable, or not an image at all: let eleventy-img report it
+    return false;
+  }
+};
 
 const stringifyAttributes = attributeMap => {
   return Object.entries(attributeMap)
@@ -38,9 +52,17 @@ const processImage = async options => {
     src = `./src${src}`;
   }
 
+  // an animated source keeps its animation, which rules out the still formats
+  const animated = await isAnimated(src);
+  if (animated) {
+    const keep = formats.filter(format => animatedFormats.includes(format));
+    formats = keep.length ? keep : ['webp'];
+  }
+
   const metadata = await Image(src, {
     widths: [...widths],
     formats: [...formats],
+    sharpOptions: animated ? {animated: true} : {},
     urlPath: '/assets/images/',
     outputDir: './dist/assets/images/',
     filenameFormat: (id, src, width, format, options) => {


### PR DESCRIPTION
Closes #69

The symptom in the issue has changed shape since eleventy-img 7, but the problem is
still there. I made a 30 frame gif to check:

- with the default formats, the animation is silently dropped. avif and jpeg get built
  from the first frame and you end up with a still image, no warning.
- asking for webp only, which is the workaround in the issue, crashes instead. The
  shortcode reads `metadata.jpeg` unconditionally, so removing jpeg from the formats
  throws a TypeError that has nothing to do with what you did.

So neither the default nor the workaround gets you an animation.

The shortcode now counts the frames of the source and, when there's more than one,
keeps only the formats that can carry an animation and tells sharp to read every frame.
The same 30 frame gif comes out as a 30 frame webp at 20 kB. Still images are untouched,
they keep avif, webp and jpeg.

`sharp` becomes a direct import here. It's already a dependency of the project,
`generate-favicons.js` uses it, and eleventy-img pulls it in anyway, so nothing new is
installed.

The first commit is the `metadata.jpeg` fix on its own, since it's what makes any custom
format list work, animated or not.